### PR TITLE
Add context doc and clarify README references

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Export JSON save files or plain-text world reports for analysis.
 Toggle overlay to show FPS, event counts, trade route stats, warnings (low morale/prosperity). Includes a deterministic “War → Blockade → Colonization → Peace” test sequence.
 
 ## 🎮 How to Play
-1. Open `Simulation.html` in a browser.
+1. Open `Simulation File v2.html` in a browser.
 2. Pick a civ in the left panel.
 3. Adjust sliders (Religion, Economy, etc.) — watch tooltips explain effects and preview “what-if” changes.
 4. Press ▶ Start and watch borders, convoys, raids, and events unfold.
@@ -70,5 +70,5 @@ Try presets:
 - Canvas rendering: Efficient redraw of hex grid, convoys, halos, and battle flares.
 - Accessibility: Keyboard shortcuts (Space = Run/Pause, N = Step, T = Test Mode).
 - Context Docs: See `/simulation/context/tess_sim_cursor_context.md` for full world bible and formulas.
-- Patches: Modular extensions (like slider hover help) live under `/simulation/patches/`.
+- Patches: planned modular extensions will live under `/simulation/patches/`.
 

--- a/simulation/context/tess_sim_cursor_context.md
+++ b/simulation/context/tess_sim_cursor_context.md
@@ -1,0 +1,17 @@
+# Tesselated Sea Simulation Context
+
+This document summarizes the lore and core mechanics behind the Tesselated Sea simulation. Use it as a reference when expanding the world or adjusting balance formulas.
+
+## Lore Highlights
+- Year 719 After the Sundering.
+- Principal civilizations: SAL, LYR, THO, KHA, and GLA.
+
+## Simulation Pillars
+- Religion
+- Government
+- Goods/Economy
+- Writing/Knowledge
+- Arts/Culture
+- Social Structure
+
+These pillars drive derived indices such as Prosperity, Stability, Innovation, Soft Power, and Military effectiveness.


### PR DESCRIPTION
## Summary
- Add missing simulation context document under `/simulation/context`
- Update README to reference new context doc, correct HTML entry point, and clarify planned patches directory

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7cf680cfc832eb5a248b3e4f029d1