### PR TITLE
Clarify patches directory reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,5 +70,5 @@ Try presets:
 - Canvas rendering: Efficient redraw of hex grid, convoys, halos, and battle flares.
 - Accessibility: Keyboard shortcuts (Space = Run/Pause, N = Step, T = Test Mode).
 - Context Docs: See `/simulation/context/tess_sim_cursor_context.md` for full world bible and formulas.
-- Patches: Modular extensions (like slider hover help) live under `/simulation/patches/`.
+- Patches: Planned modular extensions (e.g., slider hover help) will eventually live under `/simulation/patches/` (directory not yet included).
 


### PR DESCRIPTION
## Summary
- Clarify that `/simulation/patches/` is a planned location for future modular extensions, not currently included.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7cf68c784832eb1595a0f5e48fc0f