### PR TITLE
Make simulation HTML directly runnable in browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Export JSON save files or plain-text world reports for analysis.
 Toggle overlay to show FPS, event counts, trade route stats, warnings (low morale/prosperity). Includes a deterministic “War → Blockade → Colonization → Peace” test sequence.
 
 ## 🎮 How to Play
-1. Open `Simulation File v2.html` in a browser.
+1. Open `index.html` in a browser.
 2. Pick a civ in the left panel.
 3. Adjust sliders (Religion, Economy, etc.) — watch tooltips explain effects and preview “what-if” changes.
 4. Press ▶ Start and watch borders, convoys, raids, and events unfold.

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8" />
 <title>Alternate World Civilization & Geopolitics Simulator — The Tesselated Sea (719 A.S.)</title>
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<link rel="stylesheet" href="simulation/style.css">
+<link rel="stylesheet" href="./simulation/style.css">
 </head>
 <body>
 <div class="wrap" role="application" aria-label="Alternate World Civilization & Geopolitics Simulator">
@@ -284,6 +284,6 @@
   </footer>
 </div>
 
-<script src="simulation/main.js"></script>
+<script src="./simulation/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Rename `Simulation File v2.html` to `index.html` for easier launching
- Use explicit relative paths for CSS and JS
- Update README instructions to open `index.html`

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a7d4b27388832eb03b2f1143ddc233